### PR TITLE
adding Array support for watch attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'miguel.fonseca@mindera.com'
 license          'MIT'
 description      'Installs/Configures PM2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.2'
+version          '0.6.3'
 
 depends 'nodejs', '~> 2.4.0'
 

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -37,7 +37,7 @@ attribute :pid_file,            :kind_of => String
 attribute :cron_restart,        :kind_of => String
 attribute :cwd,                 :kind_of => String, :required => true
 attribute :merge_logs,          :kind_of => [TrueClass, FalseClass]
-attribute :watch,               :kind_of => [TrueClass, FalseClass]
+attribute :watch,               :kind_of => [TrueClass, FalseClass, Array]
 # ignore_watch can be an array or string in pm2 so we map it to a ruby Array
 attribute :ignore_watch,        :kind_of => Array
 # watch_options a js object in pm2 so we map it to a ruby Hash


### PR DESCRIPTION
PR adds array support for PM2 watch attribute:

http://pm2.keymetrics.io/docs/usage/watch-and-restart/

Watch can be true, false or an array of folders to watch.