### PR TITLE
Added option pm2-manage_pm2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,4 @@
 default_unless['pm2']['pm2_version'] = 'latest'
 default_unless['pm2']['npm_version'] = 'latest'
 default_unless['pm2']['node_version'] = '4.5.0'
+default_unless['pm2']['manage_pm2'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'miguel.fonseca@mindera.com'
 license 'MIT'
 description 'Installs/Configures PM2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.7.4'
+version '0.7.5'
 
 depends 'poise-javascript', '~> 1.1.0'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,11 +18,11 @@ end
   node_package pkg do
     version node['pm2']["#{pkg}_version"] unless node['pm2']["#{pkg}_version"].nil?
   end
-end
+end if node['pm2']['manage_pm2']
 
 # Link executable into system path
 %w(node pm2 npm).each do |exe|
   link "/usr/bin/#{exe}" do
     to "/opt/nodejs-#{node['pm2']['node_version']}/bin/#{exe}"
   end
-end
+end if node['pm2']['manage_pm2']


### PR DESCRIPTION
Required to manage pm2 with external tools and use only cookbook's LWRP