### PR TITLE
Loosen poise-javascript version restriction

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'miguel.fonseca@mindera.com'
 license 'MIT'
 description 'Installs/Configures PM2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.7.4'
+version '0.7.5'
 
-depends 'poise-javascript', '~> 1.1.0'
+depends 'poise-javascript', '~> 1.1'
 
 supports 'centos', '~> 6.0'
 supports 'redhat', '~> 6.0'


### PR DESCRIPTION
There is already version 1.2.0 of [poise-javascript](https://supermarket.chef.io/cookbooks/poise-javascript), which can't be used with current restriction in pm2 cookbook.